### PR TITLE
[dynamixel_sdk/CMakeLists.txt] fix: export dynamixel_sdk library for catkin

### DIFF
--- a/dynamixel_sdk/CMakeLists.txt
+++ b/dynamixel_sdk/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 catkin_package(
   INCLUDE_DIRS include
-#  LIBRARIES dynamixel_sdk
+  LIBRARIES dynamixel_sdk
 #  CATKIN_DEPENDS roscpp
 #  DEPENDS system_lib
 )

--- a/robotis_device/CMakeLists.txt
+++ b/robotis_device/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   INCLUDE_DIRS include
-#  LIBRARIES robotis_device
+  LIBRARIES robotis_device
   CATKIN_DEPENDS roscpp rospy
 #  DEPENDS system_lib
 )
@@ -56,6 +56,5 @@ add_dependencies(robotis_device ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXP
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(robotis_device
-  dynamixel_sdk
   ${catkin_LIBRARIES}
 )


### PR DESCRIPTION
This is necessary to successfully build `robotis_device` package with `catkin`.
