### PR TITLE
fixed dependency chain

### DIFF
--- a/robotis_device/CMakeLists.txt
+++ b/robotis_device/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES robotis_device
-  CATKIN_DEPENDS roscpp rospy
+  CATKIN_DEPENDS roscpp rospy dynamixel_sdk robotis_framework_common
 #  DEPENDS system_lib
 )
 

--- a/robotis_device/package.xml
+++ b/robotis_device/package.xml
@@ -26,6 +26,7 @@
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>dynamixel_sdk</run_depend>
+  <run_depend>robotis_framework_common</run_depend>
 
 
   <export>


### PR DESCRIPTION
Added missing dependencies to dynamixel_sdk and robotis_framework_common. Therefore robotis_device forwards these dependencies correctly now. No need for dependency duplication in other packages anymore. 
