### PR TITLE
separated the initialize() method fixes #79

### DIFF
--- a/robotis_controller/include/robotis_controller/robotis_controller.h
+++ b/robotis_controller/include/robotis_controller/robotis_controller.h
@@ -117,6 +117,7 @@ public:
   RobotisController();
 
   bool    initialize(const std::string robot_file_path, const std::string init_file_path);
+  bool    initialize(Robot *robot, const std::string init_file_path);
   void    initializeDevice(const std::string init_file_path);
   void    process();
 

--- a/robotis_controller/src/robotis_controller/robotis_controller.cpp
+++ b/robotis_controller/src/robotis_controller/robotis_controller.cpp
@@ -199,8 +199,14 @@ bool RobotisController::initialize(const std::string robot_file_path, const std:
   std::string dev_desc_dir_path = ros::package::getPath("robotis_device") + "/devices";
 
   // load robot info : port , device
-  robot_ = new Robot(robot_file_path, dev_desc_dir_path);
+  Robot *new_robot = new Robot(robot_file_path, dev_desc_dir_path);
+  initialize(new_robot, init_file_path);
+}
 
+
+bool RobotisController::initialize(Robot *robot, const std::string init_file_path)
+{
+  robot_ = robot;
   if (gazebo_mode_ == true)
   {
     queue_thread_ = boost::thread(boost::bind(&RobotisController::msgQueueThread, this));


### PR DESCRIPTION
In `robotis_controller` the `initialize()` method automatically creates a `Robot` instance with the information provided in the configuration files. There is no way for the user to provide additional functionality before the rest of the function interrogates the communication ports and completes the initialisation process.

I have created a second `initialize()` method that uses a `Robot *`  and now the original `initialize()` method simply creates the new `Robot` instance and calls the new method that contains all the original code from after the robot instance creation.

With this structure it is now possible in a custom controller node to perform this:

```
robotis_framework::Robot *robot = new robotis_framework::Robot(robot_file, dev_desc_dir_path);
/* Do some config on the robot instance.
   For example I am configuring the ports_ in RS485 mode.
*/
// Now call the rest of robot initialization
if(controller->initialize(robot, init_file) == false)
 {
    ROS_ERROR("ROBOTIS Controller Initialize Fail!");
    return -1;
 }
```
Of course other scenarios are possible like creating a subclass of `robotis_framework::Robot` with some special functionality that is not included in the original class and using that in the creation of the robot instance, then passing it to the `initialize(robot, init_file)`. 